### PR TITLE
pr fix(#115): 공유 포트폴리오 댓글 조회 생성순 내림차순 정렬 적용

### DIFF
--- a/portfolio-service/src/main/java/com/pda/portfolioservice/repository/SharePortfolioCommentRepository.java
+++ b/portfolio-service/src/main/java/com/pda/portfolioservice/repository/SharePortfolioCommentRepository.java
@@ -1,6 +1,7 @@
 package com.pda.portfolioservice.repository;
 
 import com.pda.portfolioservice.entity.SharePortfolioComment;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,7 +10,7 @@ import java.util.Optional;
 
 @Repository
 public interface SharePortfolioCommentRepository extends JpaRepository<SharePortfolioComment, Long> {
-    List<SharePortfolioComment> findBysharePortfolio_SharePortfolioId(Long sharePortfolioId);
+    List<SharePortfolioComment> findBysharePortfolio_SharePortfolioId(Long sharePortfolioId, Sort sort);
 
     Optional<List<SharePortfolioComment>> findByUserId(String userId);  // userId로 댓글 조회
 }

--- a/portfolio-service/src/main/java/com/pda/portfolioservice/service/PortfolioServiceImpl.java
+++ b/portfolio-service/src/main/java/com/pda/portfolioservice/service/PortfolioServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -229,7 +230,7 @@ public class PortfolioServiceImpl implements PortfolioService {
             throw new PortfolioHandler(ErrorStatus.PORTFOLIO_NOT_FOUND);
         }
 
-        List<SharePortfolioComment> comments = sharePortfolioCommentRepository.findBysharePortfolio_SharePortfolioId(sharePortfolioId);
+        List<SharePortfolioComment> comments = sharePortfolioCommentRepository.findBysharePortfolio_SharePortfolioId(sharePortfolioId, Sort.by(Sort.Direction.DESC, "createdAt"));
 
         return SharePortfolioCommentResponseDTO.toDTO(comments, userServiceClient);
     }


### PR DESCRIPTION
# 수정 내용
공유 포트폴리오 댓글 조회 생성순 내림차순 정렬을 적용했습니다. 